### PR TITLE
Align OpenAI token options with GPT-5-mini requirements

### DIFF
--- a/hysio/src/app/api/generate/route.ts
+++ b/hysio/src/app/api/generate/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
     const completionOptions: OpenAICompletionOptions = {
       model: HYSIO_LLM_MODEL,
       temperature: 1.0, // GPT-5-mini only supports temperature = 1
-      max_tokens: 2000,
+      maxTokens: 2000,
       ...options,
     };
 

--- a/hysio/src/app/api/smartmail/generate/route.ts
+++ b/hysio/src/app/api/smartmail/generate/route.ts
@@ -301,7 +301,7 @@ export async function POST(request: NextRequest) {
     const openAIOptions: OpenAICompletionOptions = {
       model: HYSIO_LLM_MODEL, // Use GPT-4 for better healthcare communication
       temperature: 1.0, // GPT-5-mini only supports temperature = 1
-      max_tokens: 2000, // Sufficient for detailed emails
+      maxTokens: 2000, // Sufficient for detailed emails
       top_p: 0.9,
       presence_penalty: 0.1,
       frequency_penalty: 0.1

--- a/hysio/src/app/api/smartmail/route.ts
+++ b/hysio/src/app/api/smartmail/route.ts
@@ -314,7 +314,7 @@ ${instructions.generate}`;
       {
         model: HYSIO_LLM_MODEL,
         temperature: 1.0, // GPT-5-mini only supports temperature = 1
-        max_tokens: 1000
+        maxTokens: 1000
       }
     );
 

--- a/hysio/src/lib/api/openai.ts
+++ b/hysio/src/lib/api/openai.ts
@@ -25,7 +25,7 @@ function getOpenAIClient(): OpenAI {
 export interface OpenAICompletionOptions {
   model?: string; // Default to gpt-5-mini
   temperature?: number; // 0-2, controls randomness
-  max_tokens?: number; // Maximum tokens in response
+  maxTokens?: number; // Maximum tokens in response
   top_p?: number; // 0-1, nucleus sampling
   frequency_penalty?: number; // -2 to 2, penalize frequent tokens
   presence_penalty?: number; // -2 to 2, penalize existing tokens
@@ -43,7 +43,7 @@ export async function generateContentWithOpenAI(
     const {
       model = HYSIO_LLM_MODEL,
       temperature = 1.0, // GPT-5-mini only supports temperature = 1
-      max_tokens = 2000,
+      maxTokens = 2000,
       top_p = 1.0,
       frequency_penalty = 0,
       presence_penalty = 0,
@@ -68,7 +68,8 @@ export async function generateContentWithOpenAI(
         { role: 'user', content: userPrompt }
       ],
       temperature,
-      max_completion_tokens: max_tokens, // GPT-5-mini uses max_completion_tokens instead of max_tokens
+      // Map camelCase option to OpenAI's expected snake_case field
+      max_tokens: maxTokens,
       top_p,
       frequency_penalty,
       presence_penalty,
@@ -236,7 +237,7 @@ export async function generateContentStreamWithOpenAI(
     const {
       model = HYSIO_LLM_MODEL,
       temperature = 1.0, // GPT-5-mini only supports temperature = 1
-      max_tokens = 2000,
+      maxTokens = 2000,
       top_p = 1.0,
       frequency_penalty = 0,
       presence_penalty = 0,
@@ -258,7 +259,8 @@ export async function generateContentStreamWithOpenAI(
         { role: 'user', content: userPrompt }
       ],
       temperature,
-      max_completion_tokens: max_tokens, // GPT-5-mini uses max_completion_tokens instead of max_tokens
+      // Map camelCase option to OpenAI's expected snake_case field
+      max_tokens: maxTokens,
       top_p,
       frequency_penalty,
       presence_penalty,

--- a/hysio/src/lib/assistant/system-prompt.ts
+++ b/hysio/src/lib/assistant/system-prompt.ts
@@ -121,7 +121,7 @@ export const EXAMPLE_QUESTIONS = [
 export const ASSISTANT_MODEL_CONFIG = {
   model: HYSIO_LLM_MODEL,
   temperature: 1.0, // GPT-5-mini only supports temperature = 1
-  max_tokens: 2000,
+  maxTokens: 2000,
   top_p: 1.0,
   frequency_penalty: 0,
   presence_penalty: 0,

--- a/hysio/src/lib/edupack/content-generator.ts
+++ b/hysio/src/lib/edupack/content-generator.ts
@@ -205,7 +205,7 @@ export class EduPackContentGenerator {
       const options: OpenAICompletionOptions = {
         model: HYSIO_LLM_MODEL,
         temperature: 1.0, // GPT-5-mini only supports temperature = 1
-        max_tokens: wordCountTokens,
+        maxTokens: wordCountTokens,
         top_p: 0.9,
         frequency_penalty: 0.2,
         presence_penalty: 0.1


### PR DESCRIPTION
## Summary
- replace the deprecated `max_completion_tokens` call parameter with `max_tokens` in both OpenAI content generation helpers
- switch the shared `OpenAICompletionOptions` contract to the camelCase `maxTokens` property and update server defaults to match
- propagate the renamed option through SmartMail, EduPack, and Assistant integrations so they reuse the unified configuration

## Testing
- npm run lint *(fails: existing lint errors throughout diagnosecode, blog, smartmail, and utility modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9110aadc832c8f770a9b9b82c035