### PR TITLE
Handle nullable request body in smartmail simple route

### DIFF
--- a/hysio/src/app/api/smartmail/simple/route.test.ts
+++ b/hysio/src/app/api/smartmail/simple/route.test.ts
@@ -1,0 +1,82 @@
+import type { NextRequest } from 'next/server';
+import type { SimpleEmailRequest } from '@/lib/types/smartmail-simple';
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+type PostHandler = typeof import('./route').POST;
+
+describe('SmartMail simple POST handler', () => {
+  let postHandler!: PostHandler;
+  const originalApiKey = process.env.OPENAI_API_KEY;
+  const originalFetch = globalThis.fetch;
+  const globalWithFetch = globalThis as typeof globalThis & { fetch?: typeof fetch };
+
+  beforeAll(async () => {
+    ({ POST: postHandler } = await import('./route'));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+
+    if (originalApiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    }
+
+    if (originalFetch) {
+      globalWithFetch.fetch = originalFetch;
+    } else {
+      delete globalWithFetch.fetch;
+    }
+  });
+
+  it('returns fallback email when parsing the request fails', async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const request = {
+      json: jest.fn().mockRejectedValue(new Error('Invalid JSON payload')),
+    } as unknown as NextRequest;
+
+    const response = await postHandler(request);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.email).toContain('Beste collega');
+    expect(data.email).toContain('Update over uw behandeling.');
+  });
+
+  it('returns fallback email when the OpenAI call fails', async () => {
+    process.env.OPENAI_API_KEY = 'test-api-key';
+
+    const requestBody: SimpleEmailRequest = {
+      recipientType: 'patient',
+      subject: 'Test onderwerp',
+      context: 'Test context',
+      length: 'kort',
+    };
+
+    const request = {
+      json: jest.fn().mockResolvedValue(requestBody),
+    } as unknown as NextRequest;
+
+    const fetchMock = jest.fn().mockRejectedValue(new Error('OpenAI failure'));
+    globalWithFetch.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await postHandler(request);
+    const data = await response.json();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(data.success).toBe(true);
+    expect(data.email).toContain('Beste patiënt');
+    expect(data.email).toContain('Test context');
+    expect(data.email).toContain('Fallback mode');
+  });
+});

--- a/hysio/src/app/api/smartmail/simple/route.ts
+++ b/hysio/src/app/api/smartmail/simple/route.ts
@@ -3,8 +3,14 @@ import { SimpleEmailRequest, SimpleEmailResponse } from '@/lib/types/smartmail-s
 import { HYSIO_LLM_MODEL } from '@/lib/api/openai';
 
 export async function POST(request: NextRequest): Promise<NextResponse<SimpleEmailResponse>> {
+  let body: SimpleEmailRequest | null = null;
+
   try {
-    const body: SimpleEmailRequest = await request.json();
+    body = await request.json();
+
+    if (!body) {
+      throw new Error('Ongeldige SmartMail aanvraag: lege body');
+    }
 
     // Basic validation - keep it simple
     if (!body.recipientType || !body.context) {
@@ -106,9 +112,11 @@ ${userInstruction}`;
       console.warn('OpenAI API failed, using fallback:', aiError);
 
       // Fallback to simple template when AI fails
-      const fallbackEmail = `Beste ${body.recipientType === 'patient' ? 'patiënt' : 'collega'},
+      const fallbackRecipient = body?.recipientType === 'patient' ? 'patiënt' : 'collega';
+      const fallbackContext = body?.context ?? 'Update over uw behandeling.';
+      const fallbackEmail = `Beste ${fallbackRecipient},
 
-${body.context}
+${fallbackContext},
 
 Met vriendelijke groet,
 [Uw naam]
@@ -127,9 +135,11 @@ Gegenereerd met Hysio SmartMail (Fallback mode)`;
     console.error('SmartMail Simple Error:', error);
 
     // Simple fallback - no complex error handling
-    const fallbackEmail = `Beste ${body?.recipientType === 'patient' ? 'patiënt' : 'collega'},
+    const fallbackRecipient = body?.recipientType === 'patient' ? 'patiënt' : 'collega';
+    const fallbackContext = body?.context ?? 'Update over uw behandeling.';
+    const fallbackEmail = `Beste ${fallbackRecipient},
 
-${body?.context || 'Update over uw behandeling.'}
+${fallbackContext},
 
 Met vriendelijke groet,
 [Uw naam]


### PR DESCRIPTION
## Summary
- declare the SmartMail simple route body outside of the try block and guard against null values
- make fallback email templates resilient to a missing request body in both catch blocks
- add a focused test to cover request parsing and OpenAI failure fallbacks using mocked Next.js responses

## Testing
- pnpm test -- --runTestsByPath src/app/api/smartmail/simple/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd991678a4832cb90179bc4fc70cde