### PR TITLE
Normalize OpenAI max token option

### DIFF
--- a/hysio/src/app/api/generate/route.ts
+++ b/hysio/src/app/api/generate/route.ts
@@ -64,9 +64,13 @@ export async function POST(request: NextRequest) {
     const completionOptions: OpenAICompletionOptions = {
       model: HYSIO_LLM_MODEL,
       temperature: 1.0, // GPT-5-mini only supports temperature = 1
-      maxTokens: 2000,
+      max_tokens: 2000,
       ...options,
     };
+
+    if (options.maxTokens !== undefined && options.max_tokens === undefined) {
+      completionOptions.max_tokens = options.maxTokens;
+    }
 
     if (stream) {
       // Handle streaming response

--- a/hysio/src/app/api/smartmail/generate/route.ts
+++ b/hysio/src/app/api/smartmail/generate/route.ts
@@ -301,7 +301,7 @@ export async function POST(request: NextRequest) {
     const openAIOptions: OpenAICompletionOptions = {
       model: HYSIO_LLM_MODEL, // Use GPT-4 for better healthcare communication
       temperature: 1.0, // GPT-5-mini only supports temperature = 1
-      maxTokens: 2000, // Sufficient for detailed emails
+      max_tokens: 2000, // Sufficient for detailed emails
       top_p: 0.9,
       presence_penalty: 0.1,
       frequency_penalty: 0.1

--- a/hysio/src/app/api/smartmail/route.ts
+++ b/hysio/src/app/api/smartmail/route.ts
@@ -314,7 +314,7 @@ ${instructions.generate}`;
       {
         model: HYSIO_LLM_MODEL,
         temperature: 1.0, // GPT-5-mini only supports temperature = 1
-        maxTokens: 1000
+        max_tokens: 1000
       }
     );
 

--- a/hysio/src/app/api/smartmail/simple/route.ts
+++ b/hysio/src/app/api/smartmail/simple/route.ts
@@ -81,7 +81,7 @@ ${userInstruction}`;
         body: JSON.stringify({
           model: HYSIO_LLM_MODEL,
           messages: [{ role: 'user', content: finalPrompt }],
-          maxTokens: 800, // Increased for document context
+          max_tokens: 800, // Increased for document context
           temperature: 1.0, // GPT-5-mini only supports temperature = 1
         }),
       });

--- a/hysio/src/components/scribe/streamlined-intake-workflow.tsx
+++ b/hysio/src/components/scribe/streamlined-intake-workflow.tsx
@@ -557,7 +557,7 @@ Antwoord in het Nederlands, professioneel geformatteerd.`;
           userPrompt,
           options: {
             temperature: 0.3,
-            maxTokens: 1500,
+            max_tokens: 1500,
           }
         }),
       });

--- a/hysio/src/lib/api/openai.ts
+++ b/hysio/src/lib/api/openai.ts
@@ -41,7 +41,9 @@ function getOpenAIClient(): OpenAI {
 export interface OpenAICompletionOptions {
   model?: string; // Default to gpt-5-mini
   temperature?: number; // GPT-5-mini only supports 1.0
-  max_tokens?: number; // Maximum tokens in response
+  max_tokens?: number; // Maximum tokens in response (canonical)
+  /** @deprecated Use max_tokens instead. Supported for backwards compatibility. */
+  maxTokens?: number;
   top_p?: number; // 0-1, nucleus sampling
   frequency_penalty?: number; // -2 to 2, penalize frequent tokens
   presence_penalty?: number; // -2 to 2, penalize existing tokens
@@ -59,13 +61,16 @@ export async function generateContentWithOpenAI(
     const {
       model = HYSIO_LLM_MODEL,
       temperature: rawTemperature,
-      max_tokens = 2000,
+      max_tokens,
+      maxTokens,
       top_p = 1.0,
       frequency_penalty = 0,
       presence_penalty = 0,
       stop,
       user,
     } = options;
+
+    const resolvedMaxTokens = max_tokens ?? maxTokens ?? 2000;
 
     const temperature = normalizeTemperature(rawTemperature);
 
@@ -87,7 +92,7 @@ export async function generateContentWithOpenAI(
       ],
       temperature,
       // Map camelCase option to OpenAI's expected snake_case field
-      max_tokens: maxTokens,
+      max_tokens: resolvedMaxTokens,
       top_p,
       frequency_penalty,
       presence_penalty,
@@ -255,7 +260,8 @@ export async function generateContentStreamWithOpenAI(
     const {
       model = HYSIO_LLM_MODEL,
       temperature: rawTemperature,
-      max_tokens = 2000,
+      max_tokens,
+      maxTokens,
       top_p = 1.0,
       frequency_penalty = 0,
       presence_penalty = 0,
@@ -267,6 +273,8 @@ export async function generateContentStreamWithOpenAI(
     } = options;
 
     const temperature = normalizeTemperature(rawTemperature);
+
+    const resolvedMaxTokens = max_tokens ?? maxTokens ?? 2000;
 
     // Get OpenAI client
     const client = getOpenAIClient();
@@ -280,7 +288,7 @@ export async function generateContentStreamWithOpenAI(
       ],
       temperature,
       // Map camelCase option to OpenAI's expected snake_case field
-      max_tokens: maxTokens,
+      max_tokens: resolvedMaxTokens,
       top_p,
       frequency_penalty,
       presence_penalty,

--- a/hysio/src/lib/assistant/system-prompt.ts
+++ b/hysio/src/lib/assistant/system-prompt.ts
@@ -121,7 +121,7 @@ export const EXAMPLE_QUESTIONS = [
 export const ASSISTANT_MODEL_CONFIG = {
   model: HYSIO_LLM_MODEL,
   temperature: 1.0, // GPT-5-mini only supports temperature = 1
-  maxTokens: 2000,
+  max_tokens: 2000,
   top_p: 1.0,
   frequency_penalty: 0,
   presence_penalty: 0,

--- a/hysio/src/lib/diagnosecode/ai-prompts.ts
+++ b/hysio/src/lib/diagnosecode/ai-prompts.ts
@@ -5,7 +5,9 @@ import { HYSIO_LLM_MODEL } from '@/lib/api/openai';
 export interface AIPromptConfig {
   systemPrompt: string;
   temperature: number;
-  maxTokens: number;
+  max_tokens: number;
+  /** @deprecated Gebruik max_tokens. Alleen voor terugwaartse compatibiliteit. */
+  maxTokens?: number;
   model: string;
 }
 
@@ -96,7 +98,7 @@ export const COMMON_SYMPTOM_PATTERNS = {
 export const AI_MODEL_CONFIG: AIPromptConfig = {
   systemPrompt: DCSPH_SYSTEM_PROMPT,
   temperature: 1.0, // GPT-5-mini only supports temperature = 1
-  maxTokens: 1000,
+  max_tokens: 1000,
   model: HYSIO_LLM_MODEL
 };
 

--- a/hysio/src/lib/edupack/content-generator.ts
+++ b/hysio/src/lib/edupack/content-generator.ts
@@ -205,7 +205,7 @@ export class EduPackContentGenerator {
       const options: OpenAICompletionOptions = {
         model: HYSIO_LLM_MODEL,
         temperature: 1.0, // GPT-5-mini only supports temperature = 1
-        maxTokens: wordCountTokens,
+        max_tokens: wordCountTokens,
         top_p: 0.9,
         frequency_penalty: 0.2,
         presence_penalty: 0.1


### PR DESCRIPTION
## Summary
- update the OpenAI completion helper to prefer `max_tokens` while still accepting legacy `maxTokens`
- switch SmartMail, EduPack, assistant, and scribe configurations to use the canonical `max_tokens` option
- adjust the SmartMail simple API fetch payload to send `max_tokens` to OpenAI

## Testing
- pnpm exec tsc --noEmit *(fails: repository currently has pre-existing type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9913b650832ca2e206085b929391