### PR TITLE
Fix OpenAI max_tokens handling

### DIFF
--- a/hysio/src/lib/api/openai.test.ts
+++ b/hysio/src/lib/api/openai.test.ts
@@ -1,0 +1,84 @@
+jest.mock('openai', () => {
+  const mockCreate = jest.fn();
+
+  const MockOpenAI = jest.fn().mockImplementation(() => ({
+    chat: {
+      completions: {
+        create: mockCreate,
+      },
+    },
+  }));
+
+  class MockAPIError extends Error {
+    status?: number;
+
+    constructor(message?: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  }
+
+  MockOpenAI.APIError = MockAPIError;
+
+  return {
+    __esModule: true,
+    default: MockOpenAI,
+    APIError: MockAPIError,
+    mockCreate,
+  };
+});
+
+const { mockCreate } = jest.requireMock('openai') as { mockCreate: jest.Mock };
+
+describe('generateContentWithOpenAI', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('returns a successful response when max_tokens is set', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: { content: 'Mock completion' },
+        },
+      ],
+      model: 'mock-model',
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    };
+
+    mockCreate.mockResolvedValueOnce(mockResponse);
+
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    const { generateContentWithOpenAI } = await import('@/lib/api/openai');
+
+    const result = await generateContentWithOpenAI('System prompt', 'User prompt', {
+      max_tokens: 150,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      content: 'Mock completion',
+      model: 'mock-model',
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+      },
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_tokens: 150,
+      }),
+    );
+  });
+});

--- a/hysio/src/lib/api/openai.ts
+++ b/hysio/src/lib/api/openai.ts
@@ -67,6 +67,7 @@ export async function generateContentWithOpenAI(
       user,
     } = options;
 
+    const maxTokensValue = max_tokens;
     const temperature = normalizeTemperature(rawTemperature);
 
     // Check if API key is available
@@ -87,7 +88,7 @@ export async function generateContentWithOpenAI(
       ],
       temperature,
       // Map camelCase option to OpenAI's expected snake_case field
-      max_tokens: maxTokens,
+      max_tokens: maxTokensValue,
       top_p,
       frequency_penalty,
       presence_penalty,
@@ -266,6 +267,7 @@ export async function generateContentStreamWithOpenAI(
       onError,
     } = options;
 
+    const maxTokensValue = max_tokens;
     const temperature = normalizeTemperature(rawTemperature);
 
     // Get OpenAI client
@@ -280,7 +282,7 @@ export async function generateContentStreamWithOpenAI(
       ],
       temperature,
       // Map camelCase option to OpenAI's expected snake_case field
-      max_tokens: maxTokens,
+      max_tokens: maxTokensValue,
       top_p,
       frequency_penalty,
       presence_penalty,


### PR DESCRIPTION
## Summary
- capture the max_tokens option in a local variable when building OpenAI requests
- reuse the stored max token value for both standard and streaming completion calls
- add a Jest test that mocks OpenAI and verifies a successful response when max_tokens is provided

## Testing
- pnpm test -- openai.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd991204a4832c865d6f50c1a4a14b